### PR TITLE
fix: fix facility filter

### DIFF
--- a/frontend/src/app/(logs)/columns.tsx
+++ b/frontend/src/app/(logs)/columns.tsx
@@ -102,7 +102,7 @@ export const columns: ColumnDef<ColumnSchema>[] = [
         </div>
       );
     },
-    filterFn: "arrIncludesSome",
+    filterFn: "arrSome",
     enableResizing: false,
     size: 100,
     minSize: 100,


### PR DESCRIPTION
Fix `_row$getValue6.includes is not a function` error when filtering by facility