### PR TITLE
fix(live): restore polling when no new logs are available

### DIFF
--- a/frontend/src/app/(logs)/_components/live-button.tsx
+++ b/frontend/src/app/(logs)/_components/live-button.tsx
@@ -44,12 +44,11 @@ export function LiveButton({ fetchPreviousPage }: LiveButtonProps) {
   }, [live, fetchPreviousPage]);
 
   // REMINDER: make sure to reset live when date is set
-  // TODO: test properly
   React.useEffect(() => {
     if ((timestamp || sort) && live) {
       setSearch((prev) => ({ ...prev, live: null }));
     }
-  }, [timestamp, sort]);
+  }, [timestamp, sort, live]);
 
   function handleClick() {
     setSearch((prev) => ({

--- a/frontend/src/app/(logs)/query-options.ts
+++ b/frontend/src/app/(logs)/query-options.ts
@@ -77,10 +77,17 @@ export const dataOptions = (search: SearchParamsType) => {
       return json as InfiniteQueryResponse<ColumnSchema[], SyslogMeta>;
     },
     initialPageParam: { cursor: Date.now(), direction: "next" },
-    getPreviousPageParam: (firstPage, _pages) => {
-      // For previous page, use the previous cursor or null if it doesn't exist
-      if (!firstPage.prevCursor) return null;
-      return { cursor: firstPage.prevCursor, direction: "prev" };
+    getPreviousPageParam: (firstPage, pages) => {
+      if (firstPage.prevCursor) {
+        return { cursor: firstPage.prevCursor, direction: "prev" };
+      }
+      // No new logs since last poll: reuse the most recent cursor from existing
+      // pages so live mode keeps polling instead of stopping permanently
+      const lastCursor = pages.find((page) => page.prevCursor)?.prevCursor;
+      if (lastCursor) {
+        return { cursor: lastCursor, direction: "prev" };
+      }
+      return null;
     },
     getNextPageParam: (lastPage, _pages) => {
       // For next page, use the next cursor or null if it doesn't exist


### PR DESCRIPTION
## Summary

Fixes #13.

In live mode, the polling loop was permanently stopping after the first interval that returned no new logs.

**Root cause:** `getPreviousPageParam` returned `null` when `prevCursor` was null (empty result from the backend). This caused TanStack Query to mark `hasPreviousPage` as `false`, making subsequent `fetchPreviousPage()` calls no-ops — the live button's polling loop kept running but never actually fetched anything.

**Fix:**

- In `query-options.ts`: when `firstPage.prevCursor` is null (no new logs), fall back to the most recent non-null cursor from existing pages so the next poll continues from the same position
- In `live-button.tsx`: added missing `live` dependency to the `useEffect` that resets live mode when `timestamp` or `sort` are set, preventing potential stale closure issues

**Behavior before:** Live mode appeared to work (button was active) but new logs never appeared after the first empty poll.

**Behavior after:** Live mode keeps polling every 4 seconds regardless of whether the previous poll returned new logs.