### PR TITLE
Fix abnormally high CPU usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM golang:1.25-trixie AS go-builder
 
 ARG VERSION=dev
+ARG DEBUG_SYMBOLS=false
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y build-essential
@@ -11,10 +12,15 @@ COPY backend/ .
 RUN mkdir -p /app/.duckdb
 
 RUN go mod download
-RUN CGO_ENABLED=1 \
-    go build \
-    -ldflags "-s -w -X sloggo/utils.Version=${VERSION}" \
-    -o sloggo main.go
+RUN if [ "$DEBUG_SYMBOLS" = "true" ]; then \
+        CGO_ENABLED=1 go build \
+            -ldflags "-X sloggo/utils.Version=${VERSION}" \
+            -o sloggo main.go; \
+    else \
+        CGO_ENABLED=1 go build \
+            -ldflags "-s -w -X sloggo/utils.Version=${VERSION}" \
+            -o sloggo main.go; \
+    fi
 
 # Stage 2: Build the React frontend
 FROM node:22-trixie-slim AS frontend-builder

--- a/backend/listener/tcp.go
+++ b/backend/listener/tcp.go
@@ -79,6 +79,10 @@ func StartTCPListener() {
 
 // handleTCPConnection handles a TCP connection
 func handleTCPConnection(conn net.Conn) {
+	handleTCPConnectionWithTimeout(conn, 30*time.Second)
+}
+
+func handleTCPConnectionWithTimeout(conn net.Conn, readTimeout time.Duration) {
 	defer conn.Close()
 
 	scanner := bufio.NewScanner(conn)
@@ -88,7 +92,7 @@ func handleTCPConnection(conn net.Conn) {
 	buffer := make([]byte, 0, 64*1024)
 	scanner.Buffer(buffer, maxScanSize)
 
-	conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+	conn.SetReadDeadline(time.Now().Add(readTimeout))
 
 	for {
 		// Scan for the next message
@@ -96,9 +100,7 @@ func handleTCPConnection(conn net.Conn) {
 			// Check for errors
 			if err := scanner.Err(); err != nil {
 				if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-					// Just a timeout, reset deadline and try again
-					conn.SetReadDeadline(time.Now().Add(30 * time.Second))
-					continue
+					return
 				}
 				log.Printf("TCP connection closed: %v", err)
 			}
@@ -107,7 +109,7 @@ func handleTCPConnection(conn net.Conn) {
 		}
 
 		// Reset deadline after successful read
-		conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+		conn.SetReadDeadline(time.Now().Add(readTimeout))
 
 		message := strings.TrimSpace(scanner.Text())
 		if message == "" {

--- a/backend/listener/tcp_test.go
+++ b/backend/listener/tcp_test.go
@@ -81,3 +81,20 @@ func TestTCPListener(t *testing.T) {
 		}
 	}
 }
+
+func TestTCPConnectionReadTimeoutClosesConnection(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+
+	done := make(chan struct{})
+	go func() {
+		handleTCPConnectionWithTimeout(serverConn, 10*time.Millisecond)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("TCP connection handler did not return after read timeout")
+	}
+}

--- a/backend/server/http_server.go
+++ b/backend/server/http_server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"log"
 	"net/http"
+	"net/http/pprof"
 	"os"
 	"sloggo/server/handlers"
 	"sloggo/utils"
@@ -21,6 +22,15 @@ func (s *Server) setupRoutes() {
 
 	// API endpoint for logs
 	mux.HandleFunc("/api/logs", handlers.LogsHandler)
+
+	if utils.Pprof {
+		log.Printf("pprof endpoints are enabled at /debug/pprof/")
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	}
 
 	// Serve static files from the frontend build
 	staticDir := "/app/public"

--- a/backend/utils/vars.go
+++ b/backend/utils/vars.go
@@ -19,6 +19,8 @@ var ApiPort string
 
 var LogRetentionMinutes int64
 
+var Pprof bool
+
 var Debug bool
 
 var Version string // Set via -X flag during build
@@ -52,6 +54,7 @@ func init() {
 	TcpPort = GetSanitizedEnvString("SLOGGO_TCP_PORT", "6514")
 	ApiPort = GetSanitizedEnvString("SLOGGO_API_PORT", "8080")
 	LogRetentionMinutes = GetSanitizedEnvInt64("SLOGGO_LOG_RETENTION_MINUTES", 30*24*60) // Default to 30 days
+	Pprof = GetSanitizedEnvString("SLOGGO_PPROF", "false") == "true"
 	Debug = GetSanitizedEnvString("SLOGGO_DEBUG", "false") == "true"
 
 	// Configure log format selection


### PR DESCRIPTION
`bufio.Scanner` stops unrecoverably after an I/O error, as clearly stated in the [Go documentation](https://pkg.go.dev/bufio#Scanner). After a read timeout, our code `continue` and called `scanner.Scan()` again, so the connection went into a tight loop after the first idle timeout, consuming one core.

Made a fix:
 - backend/listener/tcp.go: When TCP read timeout occurs, close the idle connection instead of trying to continue the same Scanner.
 - backend/listener/tcp_test.go: Added a test to ensure that the handler returns after a read timeout.

Diagnostic pprof/debug-symbols changes left.